### PR TITLE
Fix the auxiliary Samba modes.

### DIFF
--- a/release/src/router/infosvr/storage.c
+++ b/release/src/router/infosvr/storage.c
@@ -239,7 +239,7 @@ getStorageStatus(STORAGE_INFO_T *st)
 	{
 		apps_status|=APPS_STATUS_BLOCKED;
 	}
-	if(!strcmp(nvram_safe_get("st_samba_mode"), "2") || !strcmp(nvram_safe_get("st_samba_mode"), "4"))
+	if(!strcmp(nvram_safe_get("st_samba_mode"), "3") || !strcmp(nvram_safe_get("st_samba_mode"), "4"))
 	{
 		apps_status|=APPS_STATUS_SMBUSER;
 	}

--- a/release/src/router/libdisk/write_smb_conf.c
+++ b/release/src/router/libdisk/write_smb_conf.c
@@ -160,11 +160,11 @@ int main(int argc, char *argv[]) {
 	fprintf(fp, "max log size = 5\n");
 	
 	/* share mode */
-	if (!strcmp(nvram_safe_get("st_samba_mode"), "1") || !strcmp(nvram_safe_get("st_samba_mode"), "3")) {
+	if (!strcmp(nvram_safe_get("st_samba_mode"), "1") || !strcmp(nvram_safe_get("st_samba_mode"), "2")) {
 		fprintf(fp, "security = SHARE\n");
 		fprintf(fp, "guest only = yes\n");
 	}
-	else if (!strcmp(nvram_safe_get("st_samba_mode"), "2") || !strcmp(nvram_safe_get("st_samba_mode"), "4")) {
+	else if (!strcmp(nvram_safe_get("st_samba_mode"), "3") || !strcmp(nvram_safe_get("st_samba_mode"), "4")) {
 		fprintf(fp, "security = USER\n");
 		fprintf(fp, "guest ok = no\n");
 		fprintf(fp, "map to guest = Bad User\n");


### PR DESCRIPTION
`st_samba_mode == 2` is incorrectly handled as being a `USER` sharing mode, but the smb.conf generator writes no authentication lines and claims that it is `samba mode: share`. `st_samba_mode == 3` is the `USER` sharing mode that should be coupled with mode 4. (1/2 are share, 3/4 are user.)

This fixes the aforementioned discrepancy, making `st_samba_mode == 2` a useful configuration: shares are accessible without authentication, and they are granular at the folder level instead of at the disk level.
