### PR TITLE
Add chroot to busybox

### DIFF
--- a/release/src/router/busybox/config_base
+++ b/release/src/router/busybox/config_base
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.17.4
-# Wed Aug  8 19:10:06 2012
+# Wed Aug  8 19:15:22 2012
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -178,7 +178,7 @@ CONFIG_TR=y
 CONFIG_CHMOD=y
 CONFIG_CHOWN=y
 # CONFIG_FEATURE_CHOWN_LONG_OPTIONS is not set
-# CONFIG_CHROOT is not set
+CONFIG_CHROOT=y
 # CONFIG_CKSUM is not set
 # CONFIG_COMM is not set
 CONFIG_CP=y


### PR DESCRIPTION
The busybox .config is meant for busybox 1.17.1 while we have busybox 1.17.4. This resulted in some inconsistencies. They do not appear to cause problems, but it is a good idea to make the file consistent.

In addition, busybox is missing chroot. The Gentoo Linux installation procedure needs chroot to work.
