### PR TITLE
Support recent system zlib libraries

### DIFF
--- a/release/src-rt/linux/linux-2.6/scripts/squashfs/lzma/C/7zip/Compress/LZMA_Lib/ZLib.cpp
+++ b/release/src-rt/linux/linux-2.6/scripts/squashfs/lzma/C/7zip/Compress/LZMA_Lib/ZLib.cpp
@@ -31,6 +31,10 @@
 #define ZLIB_LP 0
 #define ZLIB_PB 2
 
+#ifndef OF
+#define OF(args) args
+#endif
+
 #ifdef WIN32
 #include <initguid.h>
 #else


### PR DESCRIPTION
ZLib.cpp depends on a OF macro defined in zconf.h on Ubuntu. Upstream
zlib does not contain this macro, which breaks compilation on systems
using the upstream zlib code. We define it in ZLib.cpp to restore
compatibility.

More information is available at the following address:

http://code.google.com/p/fs-uae/issues/detail?id=34

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
