### PR TITLE
Fix NAT absence report for Link layer topology discovery daemon

### DIFF
--- a/release/src/router/lldt/src/ctosl-linux.c
+++ b/release/src/router/lldt/src/ctosl-linux.c
@@ -513,7 +513,10 @@ get_net_flags(void *data)
     /* If your device has a management page at the url
             http://<device-ip-address>/
        then use the fMW flag, otherwise, remove it */
+    if (nvram_match("wan_nat_x", "1"))
     *nf = htonl(fFD | fNX | fMW);
+    else
+        *nf = htonl(fFD | fMW);
 
     return TLV_GET_SUCCEEDED;
 }


### PR DESCRIPTION
lld2d always returns NAT presence flag. Let's fix it.
