### PR TITLE
Fix ancient /etc/services

### DIFF
--- a/release/src/router/rom/rom/etc/services
+++ b/release/src/router/rom/rom/etc/services
@@ -206,7 +206,8 @@ radius		1812/udp			# Radius
 radacct		1813/tcp			# Radius Accounting
 radacct		1813/udp			# Radius Accounting
 upnp		1900/udp
-nfsd		2049/udp
+nfs		2049/tcp
+nfs		2049/udp
 zephyr-srv	2102/tcp			# Zephyr server
 zephyr-srv	2102/udp			# Zephyr server
 zephyr-clt	2103/tcp			# Zephyr serv-hm connection


### PR DESCRIPTION
The kernel-space NFS server will work only with proper /etc/services, otherwise an error:

```
rpc.nfsd: unable to resolve ANYADDR:nfs to inet address: Servname not supported for ai_socktype
rpc.nfsd: unable to set any sockets for nfsd
```

will be raised. Details is [here](http://www.novell.com/support/kb/doc.php?id=7008046). 
