### PR TITLE
linux-ntfs: include glib.h, not sub-headers

### DIFF
--- a/release/src/router/linux-ntfs-2.0.0/libntfs/gnome-vfs-method.c
+++ b/release/src/router/linux-ntfs-2.0.0/libntfs/gnome-vfs-method.c
@@ -31,9 +31,10 @@
 
 #include "gnome-vfs-method.h"	/* self */
 #include <libgnomevfs/gnome-vfs-method.h>
-#include <glib/gmessages.h>
+#include <glib.h>
+//#include <glib/gmessages.h>
 #include "gnome-vfs-module.h"
-#include <glib/ghash.h>
+//#include <glib/ghash.h>
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif

--- a/release/src/router/linux-ntfs-2.0.0/libntfs/gnome-vfs-module.c
+++ b/release/src/router/linux-ntfs-2.0.0/libntfs/gnome-vfs-module.c
@@ -25,8 +25,9 @@
 
 #include "gnome-vfs-method.h"
 #include <libgnomevfs/gnome-vfs-module.h>
-#include <glib/gmessages.h>
-#include <glib/gutils.h>	/* for g_atexit() */
+//#include <glib/gmessages.h>
+//#include <glib/gutils.h>	/* for g_atexit() */
+#include <glib.h>
 
 static void vfs_module_shutdown_atexit(void);
 


### PR DESCRIPTION
linux-ntfs needs to include glib.h, not sub-headers to compile for me (Arch Linux).
