### PR TITLE
Samba: disable external libtalloc and libtdb

### DIFF
--- a/release/src/router/samba-3.5.8/Makefile
+++ b/release/src/router/samba-3.5.8/Makefile
@@ -86,6 +86,8 @@ apps: .conf
 		--with-krb5=no \
 		--with-libsmbclient=yes \
 		--with-shared-modules=MODULES \
+		--disable-external-libtalloc \
+		--disable-external-libtdb \
 		--disable-static \
 		--disable-cups \
 		--disable-iprint \


### PR DESCRIPTION
If host has libtalloc/libtdb dev packages installed (my Gentoo has), build system finds them on configuration stage and expects samba to be compiled/linked against them. Proposed fix forces to use shipped libs.
