### PR TITLE
Provide correct path to toolchain

### DIFF
--- a/tools/brcm/hndtools-mipsel-uclibc-4.2.4
+++ b/tools/brcm/hndtools-mipsel-uclibc-4.2.4
@@ -1,0 +1,1 @@
+hndtools-mipsel-uclibc


### PR DESCRIPTION
The cross compiler toolchain used by Asuswrt has its own headers and
libraries, which represent the headers and libraries of the target
system. The path was hard coded /opt/brcm/hndtools-mipsel-uclibc-4.2.4
when the toolchain was built. However, the current directory tree does
not create this path, which causes it to fallback on the system compiler
directories. This fallback is a bad idea, but unfortunately, the
toolchain does it anyway.

While the fallback is done for both libraries and headers, the inherit
incompatibility of MIPS and x86 will always result in build failures
when the two are mixed. This forced Asus to design the firmware's build
system to always rely upon the MIPS binaries. Unfortunately, the same is
not true for headers. Asus worked around the problem by using software
in their firmware that is at least semi-compatible with the Ubuntu
development packages.

That avoided build failures on Ubuntu. However, the massive hack that
Asus employed had three additional consequences:
1.  Compiler warnings
2.  Runtime failures whenever assumptions about bit fields are
   broken by the host system's headers.
3.  Build failures whenever required headers are either absent or
   incompatible on the host system.

We can resolve #1, #2 and most instances of #3 simply by
installing the proper symlink. Full resolution of #3 relies on
ensuring that the proper headers are available at all times. We can
accomplish this in any of two ways on a case-by-case basis:
1.  Install header files into the toolchain's include directory.
   This is basically what Asus did, with the caveat that we would
   no longer be relying on the host system's include directory.
2.  Modify the individual build systems to pass the proper paths to
   dependent headers. This is how Asus avoided mixing libraries.

The former requires developers emulate a package manager while the
latter is fairly easy to do without one, so it should make the most
sense to do only the latter in additional patches. This would eliminate
the need for people building the firmware to install *-devel packages
for various headers and also ensure that any GNU/Linux distribution can
run the same build process. If additional work is done to document how
the cross compiler is built, then it would become easy to build the
firmware on any UNIX-compatible system, such as *BSD, Cygwin, Mac OS X,
Solaris and others.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu

P.S. I knew about this for a year, but I hack on my router so infrequently that I only opened a pull request now. While my own repository is somewhat outdated, I build tested this against the latest code from RMerl/asuswrt-merlin on Gentoo Linux amd64. This patch is the difference between being able to build the firmware and having a build failure on Gentoo, and probably many other distributions. This patch should enable the firmware to build on Ubuntu systems without the *-devel packages installed. If you have a build failure without *-devel packages, it is a bug.
