### PR TITLE
Pass --without-libproxy to neon build system

### DIFF
--- a/release/src/router/Makefile
+++ b/release/src/router/Makefile
@@ -2193,7 +2193,7 @@ libxml2-clean:
 #add install neon 
 neon/stamp-h1:
 	cd neon && \
-	./configure CC=$(CC) --build=i686-linux --host=mipsel-linux --target=mipsel-linux --enable-shared --disable-static --disable-nls --with-zlib --with-ssl=openssl --with-libs=$(TOP)/openssl:$(TOP)/libxml2 CFLAGS='-I$(TOP)/zlib -I$(TOP)/libxml2/include -I$(TOP)/openssl/include' LDFLAGS='-L$(TOP)/libxml2/.libs -L$(TOP)/openssl -L$(TOP)/zlib' LIBS='-lxml2 -lssl -lcrypto -lz'
+	./configure CC=$(CC) --build=i686-linux --host=mipsel-linux --target=mipsel-linux --enable-shared --disable-static --disable-nls --without-libproxy --with-zlib --with-ssl=openssl --with-libs=$(TOP)/openssl:$(TOP)/libxml2 CFLAGS='-I$(TOP)/zlib -I$(TOP)/libxml2/include -I$(TOP)/openssl/include' LDFLAGS='-L$(TOP)/libxml2/.libs -L$(TOP)/openssl -L$(TOP)/zlib' LIBS='-lxml2 -lssl -lcrypto -lz'
 	cp -f neon/config.h neon/src/config.h
 	touch $@
 


### PR DESCRIPTION
We neither build nor use libproxy, but autodetection will sometimes
build support for it when the host has it installed, which breaks the
build process because proxy.h cannot be found. We disable it explicitly
to prevent this.

Signed-off-by: Richard Yao ryao@cs.stonybrook.edu
