### PR TITLE
Remove trailing LF characters from short host names too.

### DIFF
--- a/release/src/router/httpd/httpd.c
+++ b/release/src/router/httpd/httpd.c
@@ -258,8 +258,7 @@ void sethost(char *host)
 
 	strcpy(host_name, host);
 
-	cp = host_name;
-	for ( cp = cp + 9; *cp && *cp != '\r' && *cp != '\n'; cp++ );
+	for ( cp = host_name; *cp && *cp != '\r' && *cp != '\n'; cp++ );
 	*cp = '\0';
 }
 


### PR DESCRIPTION
External commands like 'ping', 'traceroute', etc. didn't work properly with Safari when short hostname was used to access the web-ui (for ex. just "router").
Asus's code applies an offset of 9 bytes to the hostname, before scanning for its end. This does not seem to make much sense... If host name is too short, the LF character gets through and this breaks the external commands execution when using Safari. Firefox, interestingly, does not need this patch.
