### PR TITLE
Update wlif_utils.h

### DIFF
--- a/release/src/router/shared/wlif_utils.h
+++ b/release/src/router/shared/wlif_utils.h
@@ -29,7 +29,7 @@
 #define ETHER_ADDR_LEN 6
 #endif
 
-#define WLIFU_MAX_NO_BRIDGE		2
+#define WLIFU_MAX_NO_BRIDGE		5
 #define WLIFU_MAX_NO_WAN		2
 
 #define MAX_USER_KEY_LEN	80			/* same as NAS_WKSP_MAX_USER_KEY_LEN */


### PR DESCRIPTION
This will raise the limit from 2 to 5 possible Bridges with WLAN and WPA. 

Default:
2 bridges with WLAN WPA are supported. 
The third bridge will not support security, like WPA, on the associated WLAN.

Fixed already Tomato:
http://repo.or.cz/w/tomato.git/commit/d1b97fef19bec4e5714b0c01f2cc748dfa788e00
