### PR TITLE
Web interface: Change DDNS user name string when Namecheap is selected

### DIFF
--- a/release/src/router/www/Advanced_ASUSDDNS_Content.asp
+++ b/release/src/router/www/Advanced_ASUSDDNS_Content.asp
@@ -385,7 +385,7 @@ function cleandef(){
 				</td>
 			</tr>			
 			<tr>
-				<th><#LANHostConfig_x_DDNSUserName_itemname#></th>
+				<th id="ddns_username_th"><#LANHostConfig_x_DDNSUserName_itemname#></th>
 				<td><input type="text" maxlength="32" class="input_25_table" name="ddns_username_x" value="<% nvram_get("ddns_username_x"); %>" onKeyPress="return is_string(this, event)"></td>
 			</tr>
 			<tr>

--- a/release/src/router/www/general.js
+++ b/release/src/router/www/general.js
@@ -1064,6 +1064,10 @@ function change_ddns_setting(v){
 				
 				showhide("wildcard_field",!disable_wild);
 		}
+		if(v == "WWW.NAMECHEAP.COM")
+			$("ddns_username_th").innerHTML = Untranslated.namecheap_username_title;
+		else
+			$("ddns_username_th").innerHTML = "<#LANHostConfig_x_DDNSUserName_itemname#>";
 }
 
 function change_common_radio(o, s, v, r){

--- a/release/src/router/www/help.js
+++ b/release/src/router/www/help.js
@@ -2,6 +2,7 @@
 	fw_size_higher_mem : 'Memory space is NOT enough to upgrade on internet. Please wait for rebooting.',
 	the_array_is_end : "end here.",
 	Guest_Network_enable_ACL : "You must go to enable MAC filter",	
+	namecheap_username_title: "Domain Name",
 	link_rate : "Link rate"
 };
 var clicked_help_string = "<#Help_init_word1#> <a class=\"hintstyle\" style=\"background-color:#7aa3bd\"><#Help_init_word2#></a> <#Help_init_word3#>";


### PR DESCRIPTION
Changes the string to "Domain Name" to more clearly document what is
expected in this field.

This fixes #472
