### PR TITLE
ipv6_ra_conf is incorrectly set in rdnssd when an ISP uses DHCPv6

### DIFF
--- a/release/src/router/ndisc6/rdnssd/icmp.c
+++ b/release/src/router/ndisc6/rdnssd/icmp.c
@@ -108,7 +108,7 @@ static int icmp_recv (int fd)
 			mylog("Get IPv6 address & DNS from DHCPv6");
 			if(last_flag != 1)
 				system("rc rc_service stop_ipv6");
-			nvram_set("ipv6_ra_conf", "oset");
+			nvram_set("ipv6_ra_conf", "mset");
 			system("rc rc_service start_dhcp6c");
 			last_flag = icmp6.nd_ra_flags_reserved;
 		}else if ( (icmp6.nd_ra_flags_reserved & ND_RA_FLAG_OTHER) && last_flag != icmp6.nd_ra_flags_reserved){


### PR DESCRIPTION
Correctly set ipv6_ra_conf="mset" in the "managed" case. When ipv6_ra_conf is set to 'oset' the dhcp6c.conf file does not include an IA_NA section which results in dhcp6c not requesting an IPv6 WAN address.

This caused problems for at least one Singapore ISP and for Comcast users only resulted in a lack of IPv6 WAN address.
