### PR TITLE
Skip NVRAM commits when resetting to defaults on MIPSEL routers.

### DIFF
--- a/release/src/router/nvram/nvram_linux.c
+++ b/release/src/router/nvram/nvram_linux.c
@@ -192,6 +192,13 @@ int nvram_commit(void)
 {
 	int r = 0;
 	FILE *fp;
+
+	if (nvram_get(ASUS_STOP_COMMIT) != NULL)
+	{
+		cprintf("# skip nvram commit #\n");
+		return r;
+	}
+
 	fp = fopen("/var/log/commit_ret", "w");
 
 	if (wait_action_idle(10)) {


### PR DESCRIPTION
Forgotten part from GPL code.
http://pastebin.com/d6i0KRee
