### PR TITLE
New URL for Entware installer

### DIFF
--- a/release/src/router/others/entware-setup.sh
+++ b/release/src/router/others/entware-setup.sh
@@ -104,6 +104,5 @@ eval sed -i 's,__Partition__,$entPartition,g' /jffs/scripts/post-mount
 chmod +x /jffs/scripts/post-mount
 
 echo -e "$INFO Starting Entware deployment....\n"
-wget http://wl500g-repo.googlecode.com/svn/ipkg/entware_install.sh
+wget http://entware.wl500g.info/binaries/entware/installer/entware_install.sh
 sh ./entware_install.sh
-


### PR DESCRIPTION
Entware packages has moved from googlecode SVN tree to our own hosting.

All installed Entware copies will be redirected to new URL automatically after `opkg update && opkg upgrade`
