### PR TITLE
samba: Fix build when tdb and/or talloc are installed.

### DIFF
--- a/release/src/router/samba-3.5.8/Makefile
+++ b/release/src/router/samba-3.5.8/Makefile
@@ -106,6 +106,8 @@ apps: .conf
 		--disable-krb5developer \
 		--disable-developer \
 		--disable-debug \
+		--disable-external-libtdb \
+		--disable-external-libtalloc \
 		--without-ads \
 		--without-acl-support \
 		--without-ldap \


### PR DESCRIPTION
If the `tdb` or `talloc` libraries are installed on the host system when building asuswrt, Samba's build system will attempt to use those instead of the in-tree sources, which breaks the build. This patch ensures that the in-tree sources of these libraries are always used.
