### PR TITLE
Use a pkg-config wrapper during cross-compilation.

### DIFF
--- a/release/src/router/common.mak
+++ b/release/src/router/common.mak
@@ -61,6 +61,9 @@ export STRIP := $(CROSS_COMPILE)strip -R .note -R .comment
 endif
 export SIZE := $(CROSS_COMPILE)size
 
+# Use a pkg-config wrapper to avoid pulling in host libs during cross-compilation.
+export PKG_CONFIG := $(shell which asuswrt-pkg-config)
+
 # Determine kernel version
 SCMD=sed -e 's,[^=]*=[        ]*\([^  ]*\).*,\1,'
 KVERSION:=	$(shell grep '^VERSION[ 	]*=' $(LINUXDIR)/Makefile|$(SCMD))

--- a/release/tools/asuswrt-pkg-config
+++ b/release/tools/asuswrt-pkg-config
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+export PKG_CONFIG_DIR=
+export PKG_CONFIG_LIBDIR=$STAGEDIR/usr/lib/pkgconfig:$STAGEDIR/usr/share/pkgconfig
+export PKG_CONFIG_SYSROOT_DIR=$STAGEDIR
+
+exec pkg-config "$@"


### PR DESCRIPTION
See #421 and #609. This prevents the build system from trying to use headers and libraries
on the host machine when building for a different architecture.

The build system doesn't actually use pkg-config, but several configure scripts complain if it's missing. This wrapper script works by pointing pkg-config at `$STAGEDIR`, which is empty during compilation, effectively ensuring pkg-config won't find any libraries. (The directory used is essentially arbitrary as long as it doesn't have any pkg-config data; I'm open to other ideas.)

I put the script in `release/tools` because the build system always adds that directory to the PATH, and because the script is the same for both MIPS and ARM, so it doesn't need to be in both of their respective toolchain directories. Again, I'm open to any better ideas here.
