### PR TITLE
flac: Use configure flags instead of *FLAGS variables.

### DIFF
--- a/release/src/router/Makefile
+++ b/release/src/router/Makefile
@@ -2118,11 +2118,11 @@ endif
 flac/stamp-h1: libogg
 	cd flac && \
 	CFLAGS="-Os $(EXTRACFLAGS) -fPIC -ffunction-sections -fdata-sections" \
-	CPPFLAGS="-I$(TOP)/libogg/include" \
-	LDFLAGS="-L$(TOP)/libogg/src/.libs -fPIC -ffunction-sections -fdata-sections -Wl,--gc-sections" \
+	LDFLAGS="-fPIC -ffunction-sections -fdata-sections -Wl,--gc-sections" \
 	$(CONFIGURE) --enable-shared --enable-static --prefix='' --disable-rpath \
 		--disable-doxygen-docs --disable-xmms-plugin --disable-cpplibs \
-		--without-libiconv-prefix --disable-altivec --disable-3dnow --disable-sse
+		--without-libiconv-prefix --disable-altivec --disable-3dnow --disable-sse \
+		--with-ogg-includes=$(TOP)/libogg/include --with-ogg-libraries=$(TOP)/libogg/src/.libs
 	touch $@
 
 flac: flac/stamp-h1 libogg


### PR DESCRIPTION
For some reason, the flac configure script adds `-L/lib/` to `OGG_LIBS` if the `--with-ogg-libraries` flag is not given on the command line. This causes the build system to try to link some binaries to `/lib/libm.so`, which won't work since we're cross-compiling.

Currently, flac gets pointed at libogg using special `CPPFLAGS` and `LDFLAGS`. This patch changes the configure call to use `--with-ogg-includes` and `--with-ogg-libraries`, which fixes the failure and is a bit cleaner.

Oddly, I only encountered this problem when building for ARM.
