### PR TITLE
OVPN: remove firewall 'sed' more specific and

### DIFF
--- a/release/src/router/rc/openvpn.c
+++ b/release/src/router/rc/openvpn.c
@@ -496,7 +496,7 @@ void stop_vpnclient(int clientNum)
 	sprintf(&buffer[0], "/etc/openvpn/fw/client%d-fw.sh", clientNum);
 	argv[0] = "sed";
 	argv[1] = "-i";
-	argv[2] = "s/-A/-D/g;s/-I/-D/g";
+	argv[2] = "s/-A/-D/g;s/-I/-D/g;s/FORWARD\ [0-9]\ /FORWARD\ /g";
 	argv[3] = &buffer[0];
 	argv[4] = NULL;
 	if (!_eval(argv, NULL, 0, NULL))


### PR DESCRIPTION
caught my firewall script using FORWARD 4 instead of 2.  added to client firewall sed
