### PR TITLE
FIX: Incorrect IPv6 prefix length when not /64

### DIFF
--- a/release/src/router/shared/misc.c
+++ b/release/src/router/shared/misc.c
@@ -708,10 +708,8 @@ const char *getifaddr(char *ifname, int family, int flags)
 		if (addr && inet_ntop(ifa->ifa_addr->sa_family, addr, buf, sizeof(buf)) != NULL) {
 			if (netmask && (flags & GIF_PREFIXLEN)) {
 				int len = 0;
-				for (i = 0; netmask[i] == 0xff && len < maxlen; i++)
-					len += 8;
-				for (i = netmask[i]; i && len < maxlen; i <<= 1)
-					len++;
+				for (i = 0; netmask[i] != 0 && len < maxlen; i++)
+					len += (9 - ffs(netmask[i]));
 				if (len < maxlen) {
 					i = strlen(buf);
 					snprintf(&buf[i], sizeof(buf)-i, "/%d", len);


### PR DESCRIPTION
in getifaddr (which is used to set the nvram ipv6 variables in uhcpd), bitwise 
operations are used to calculate the last byte of the netmask on prefix lengths that 
are not multiples of 8 (see line 712). Unfortunately, these are being performed on a 
32-bit integer, not an 8-bit char. So /60 ends up becoming /84, for example.

This bug results in non-/64 block IPv6 prefixes that are delegated via DHCP-PD to be recorded incorrectly. The incorrect prefix length is recorded in nvram and used by dhcps and radvd, but the correct prefix assigned to the bridge interface remains unchanged. As a result, DNS and router advertisement are broken.

changing this function to use ffs() instead to calculate the least significant bit fixes the length calculation, and resolved this but.
