### PR TITLE
Bring back USB_HID support.

### DIFF
--- a/release/src-rt/linux/linux-2.6/config_base
+++ b/release/src-rt/linux/linux-2.6/config_base
@@ -1308,22 +1308,22 @@ CONFIG_SND_USB_AUDIO=m
 #
 # HID Devices
 #
-# CONFIG_HID is not set
+CONFIG_HID=m
 # CONFIG_HID_DEBUG is not set
 
 #
 # USB Input Devices
 #
-# CONFIG_USB_HID is not set
+CONFIG_USB_HID=m
 # CONFIG_USB_HIDINPUT_POWERBOOK is not set
 # CONFIG_HID_FF is not set
-# CONFIG_USB_HIDDEV is not set
+CONFIG_USB_HIDDEV=y
 
 #
 # USB HID Boot Protocol drivers
 #
-# CONFIG_USB_KBD is not set
-# CONFIG_USB_MOUSE is not set
+CONFIG_USB_KBD=m
+CONFIG_USB_MOUSE=m
 
 #
 # USB support


### PR DESCRIPTION
…which was stolen by f597be75a289dab89ee7d2448517dd1197e718ea.
USB relays, UPS and other HID devices will be alive again.
