### PR TITLE
samba36: disable dnsupdate

### DIFF
--- a/release/src/router/samba36/Makefile
+++ b/release/src/router/samba36/Makefile
@@ -117,7 +117,8 @@ apps: .conf
 		--without-quotas \
 		--without-libtalloc \
 		--without-libtevent \
-		--without-sys-quotas
+		--without-sys-quotas \
+		--without-dnsupdate
 	touch .conf
 	mkdir -p $(srcdir)/bin
 


### PR DESCRIPTION
This fixes a compilation issue with addns. DNS updates are only used
by Active Directory, which is already disabled.
