### PR TITLE
dnsmasq: Allow dnsnames in dhcp static leases

### DIFF
--- a/release/src/router/rc/common.c
+++ b/release/src/router/rc/common.c
@@ -1362,6 +1362,27 @@ is_valid_hostname(const char *name)
 	return len;
 }
 
+int
+is_valid_dnsname(const char *name)
+{
+	int len, i;
+
+	if (!name)
+		return 0;
+
+	len = strlen(name);
+	for (i = 0; i < len ; i++) {
+		if (name[i] != '.' && is_invalid_char_for_hostname(name[i])) {
+			len = 0;
+			break;
+		}
+	}
+#if 0
+	printf("%s is %svalid for dnsname\n", name, len ? "" : "in");
+#endif
+	return len;
+}
+
 int get_meminfo_item(const char *name)
 {
 	int ret = 0;

--- a/release/src/router/rc/services.c
+++ b/release/src/router/rc/services.c
@@ -2292,7 +2292,7 @@ void write_static_leases(char *file)
 		if ((vars == 2) || (vars == 3)) {
 			if(strlen(mac)==0||strlen(ip)==0) continue;
 			fprintf(fp, "%s %s\n", mac, ip);
-			if ((vars == 3) && (strlen(name) > 0) && (is_valid_hostname(name))) {
+			if ((vars == 3) && (strlen(name) > 0) && (is_valid_dnsname(name))) {
 				fprintf(fp2, "%s %s\n", ip, name);
 			}
 		} else {


### PR DESCRIPTION
If a DHCP static lease was create with a hostname containing dots it won't be added to /etc/hosts.dnsmasq and, as result, such names won't be resolved by DNS. This pull request resolve this issue.
