### PR TITLE
Don't respond to DHCPv6 solicit messages for ra-stateless mode

### DIFF
--- a/release/src/router/dnsmasq/src/rfc3315.c
+++ b/release/src/router/dnsmasq/src/rfc3315.c
@@ -800,6 +800,19 @@ static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_
 	  }
 	else
 	  { 
+	    int all_stateless = 1;
+	    for (c = state->context; c; c = c->current)
+		if (!(c->flags & CONTEXT_RA_STATELESS))
+		  {
+		    all_stateless = 0;
+		    break;
+		 }
+	    if (all_stateless)
+		/* Windows 8 always requests an address even if the Managed bit
+		   in RA is 0 and it keeps retrying if it receives a reply
+		   stating that no addresses are available */
+		return 0;
+
 	    /* no address, return error */
 	    o1 = new_opt6(OPTION6_STATUS_CODE);
 	    put_opt6_short(DHCP6NOADDRS);


### PR DESCRIPTION
By not responding to a solicit message we stop Windows 8 clients from requesting a DHCPv6 over and over again, which should also clean up the noise in the syslog.

According to http://tools.ietf.org/html/rfc3315#section-17.2.1, we are allowed to discard solicit messages "if the server is not permitted to respond to the client".
We can argue that this change does not violate the RFC if dnsmasq.conf is set to ra-stateless mode, because in that case no IPv6 addresses are allowed to be assigned to any client.

Note that in ra-stateless mode DNS servers are still available via DHCPv6 (via an information request message).