### PR TITLE
SegFault in httpd

### DIFF
--- a/release/src/router/httpd/sysdeps/web-broadcom-wl6.c
+++ b/release/src/router/httpd/sysdeps/web-broadcom-wl6.c
@@ -1552,8 +1552,7 @@ ej_wl_status(int eid, webs_t wp, int argc, char_t **argv, int unit)
 				else
 					ret += websWrite(wp, " %3ddBm ", scb_val.val);
 
-				sta_info_t *sta = wl_sta_info(name, &auth->ea[ii]);
-				if (sta && (sta->flags & WL_STA_SCBSTATS))
+				if (sta->flags & WL_STA_SCBSTATS)
 				{
 // Rate
 					if ((int)sta->rx_rate > 0)


### PR DESCRIPTION
Opening the Wireless Log page will cause httpd to crash if a wireless client was connected to a guest network.

This seems to be caused by the call to wl_sta_info on line 1555 after the call on line 1510 (with a different first parameter).