### PR TITLE
Patch Makefile to handle openpam linking issue

### DIFF
--- a/release/src/router/Makefile
+++ b/release/src/router/Makefile
@@ -2937,9 +2937,6 @@ openpam-configure:
 	( cd openpam && ./autogen.sh && \
 		LDFLAGS=-ldl \
 		$(CONFIGURE) \
-		--prefix=/usr \
-		--bindir=/usr/sbin \
-		--libdir=/usr/lib \
 		--without-doc --with-pam-unix \
 	)
 


### PR DESCRIPTION
Even after https://github.com/RMerl/asuswrt-merlin/commit/6c0a94becfd74ac96d18207c9f530dc75a492423 I kept having issues with openpam failing at the make install stage, this change in the makefile is allowing openpam to build and install without trying to link with the libs of the build host.