### PR TITLE
Wireless Log enhancements

### DIFF
--- a/release/src/router/httpd/sysdeps/web-broadcom-wl6.c
+++ b/release/src/router/httpd/sysdeps/web-broadcom-wl6.c
@@ -1390,9 +1390,9 @@ ej_wl_status(int eid, webs_t wp, int argc, char_t **argv, int unit)
 
 	ret += websWrite(wp, "\n");
 #ifdef RTCONFIG_QTN
- 	ret += websWrite(wp, "Stations  (flags: S=Short GI, T=STBC)\n");
+ 	ret += websWrite(wp, "Stations  (flags: S=Short GI, T=STBC, A=Associated, U=Authenticated)\n");
 #else
-	ret += websWrite(wp, "Stations  (flags: P=Powersave Mode, S=Short GI, T=STBC)\n");
+	ret += websWrite(wp, "Stations  (flags: P=Powersave Mode, S=Short GI, T=STBC, A=Associated, U=Authenticated)\n");
 #endif
 
  	ret += websWrite(wp, "----------------------------------------\n");

--- a/release/src/router/httpd/sysdeps/web-broadcom-wl6.c
+++ b/release/src/router/httpd/sysdeps/web-broadcom-wl6.c
@@ -1529,7 +1529,7 @@ ej_wl_status(int eid, webs_t wp, int argc, char_t **argv, int unit)
 					arplistptr = arplist;
 
 					while ((arplistptr < arplist+strlen(arplist)-2) && (sscanf(arplistptr,"%15s %*s %*s %17s",ipentry,macentry) == 2)) {
-						if (upper_strcmp(macentry, ether_etoa((void *)&auth->ea[i], ea)) == 0) {
+						if (upper_strcmp(macentry, ether_etoa((void *)&auth->ea[ii], ea)) == 0) {
 							found = 1;
 							break;
 						} else {
@@ -1547,7 +1547,7 @@ ej_wl_status(int eid, webs_t wp, int argc, char_t **argv, int unit)
 					leaselistptr = leaselist;
 
 					while ((leaselistptr < leaselist+strlen(leaselist)-2) && (sscanf(leaselistptr,"%*s %17s %15s %15s %*s", macentry, ipentry, hostnameentry) == 3)) {
-						if (upper_strcmp(macentry, ether_etoa((void *)&auth->ea[i], ea)) == 0) {
+						if (upper_strcmp(macentry, ether_etoa((void *)&auth->ea[ii], ea)) == 0) {
 							found += 2;
 							break;
 						} else {


### PR DESCRIPTION
A/U flags are shown but not explained.

I have noticed that sometimes the Wireless Log page does not show the IP for all wireless clients, even though the DHCP leases page does show the IP.
Pinging the IP on the router did cause it to be shown in the Wireless Log, so it appears that when the ARP cache entry expired the IP would not be shown, even though it was known to the router.