### PR TITLE
Align connected time when over 100 hours

### DIFF
--- a/release/src/router/httpd/sysdeps/web-broadcom-wl6.c
+++ b/release/src/router/httpd/sysdeps/web-broadcom-wl6.c
@@ -1483,7 +1483,7 @@ ej_wl_status(int eid, webs_t wp, int argc, char_t **argv, int unit)
 			hr = sta->in / 3600;
 			min = (sta->in % 3600) / 60;
 			sec = sta->in - hr * 3600 - min * 60;
-			ret += websWrite(wp, "%02d:%02d:%02d  ", hr, min, sec);
+			ret += websWrite(wp, "%3d:%02d:%02d ", hr, min, sec);
 
 // Flags
 #ifdef RTCONFIG_BCMARM
@@ -1595,7 +1595,7 @@ ej_wl_status(int eid, webs_t wp, int argc, char_t **argv, int unit)
 					hr = sta->in / 3600;
 					min = (sta->in % 3600) / 60;
 					sec = sta->in - hr * 3600 - min * 60;
-					ret += websWrite(wp, "%02d:%02d:%02d  ", hr, min, sec);
+					ret += websWrite(wp, "%3d:%02d:%02d ", hr, min, sec);
 
 // Flags
 #ifdef RTCONFIG_BCMARM


### PR DESCRIPTION
The Wireless Log misaligns the connected time (and also the flags).
````
MAC               IP Address      Name              RSSI    Rx/Tx Rate   Connected Flags
XX:XX:XX:XX:XX:XX 192.168.1.XXX   XXXXXXXXXXXXX     34dBm   12/1 Mbps    00:14:36  PAU
XX:XX:XX:XX:XX:XX 192.168.1.XX    XXXXXXXX          24dBm   ??/1 MBps    20:04:35   AU
XX:XX:XX:XX:XX:XX 192.168.1.XXX   XXXXXXXXXXX       13dBm   ??/65 Mbps   120:03:00  PAU
````
With my changes, it looks like this:
````
MAC               IP Address      Name              RSSI    Rx/Tx Rate   Connected Flags
XX:XX:XX:XX:XX:XX 192.168.1.XXX   XXXXXXXXXXXXX     34dBm   12/1 Mbps      0:14:36 PAU
XX:XX:XX:XX:XX:XX 192.168.1.XX    XXXXXXXX          24dBm   ??/1 MBps     20:04:35  AU
XX:XX:XX:XX:XX:XX 192.168.1.XXX   XXXXXXXXXXX       13dBm   ??/65 Mbps   120:03:00 PAU
````
