### PR TITLE
Set the pkg-config path in common.mak instead of a script.

### DIFF
--- a/release/src-rt-6.x.4708/btools/asuswrt-pkg-config
+++ b/release/src-rt-6.x.4708/btools/asuswrt-pkg-config
@@ -1,1 +1,0 @@
-../../src/btools/asuswrt-pkg-config

--- a/release/src-rt-7.x.main/src/btools/asuswrt-pkg-config
+++ b/release/src-rt-7.x.main/src/btools/asuswrt-pkg-config
@@ -1,1 +1,0 @@
-../../../src/btools/asuswrt-pkg-config

--- a/release/src/btools/asuswrt-pkg-config
+++ b/release/src/btools/asuswrt-pkg-config
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-export PKG_CONFIG_DIR=
-export PKG_CONFIG_LIBDIR=$STAGEDIR/usr/lib/pkgconfig:$STAGEDIR/usr/share/pkgconfig
-export PKG_CONFIG_SYSROOT_DIR=$STAGEDIR
-
-exec pkg-config "$@"

--- a/release/src/router/common.mak
+++ b/release/src/router/common.mak
@@ -44,9 +44,6 @@ export STRIP := $(CROSS_COMPILE)strip -R .note -R .comment
 endif
 export SIZE := $(CROSS_COMPILE)size
 
-# Use a pkg-config wrapper to avoid pulling in host libs during cross-compilation.
-export PKG_CONFIG := $(SRCBASE)/btools/asuswrt-pkg-config
-
 # Determine kernel version
 SCMD=sed -e 's,[^=]*=[        ]*\([^  ]*\).*,\1,'
 KVERSION:=	$(shell grep '^VERSION[ 	]*=' $(LINUXDIR)/Makefile|$(SCMD))
@@ -72,6 +69,7 @@ export TARGETDIR := $(PLATFORMDIR)/target
 export STAGEDIR := $(PLATFORMDIR)/stage
 export PKG_CONFIG_SYSROOT_DIR := $(STAGEDIR)
 export PKG_CONFIG_PATH := $(STAGEDIR)/usr/lib/pkgconfig:$(STAGEDIR)/etc/lib/pkgconfig
+export PKG_CONFIG_LIBDIR := $(STAGEDIR)/usr/lib/pkgconfig:$(STAGEDIR)/usr/share/pkgconfig
 
 export EXTRACFLAGS += -DLINUX_KERNEL_VERSION=$(LINUX_KERNEL_VERSION) $(if $(STAGING_DIR),--sysroot=$(STAGING_DIR))
 


### PR DESCRIPTION
After looking at commit 4ff61dc875e369ca6977ea99490d30bd743d04e0 I noticed the following:

In GPL 378_3762 (68a34ba08be12bb965cee6fc993a4863f8f0c1e5), it looks like ASUS tried to fix the pkg-config problem themselves, but instead of using a wrapper script, they set the pkg-config environment variables directly in `common.mak`. This is a simpler solution, but unfortunately they forgot to set `PKG_CONFIG_LIBDIR`, so the build is still broken without the script.

This pull request removes the wrapper script (and symlinks thereto) and adds the required exports to `common.mak`.