### PR TITLE
Update entware-setup.sh script - Mipsel

### DIFF
--- a/release/src/router/others/entware.mips/entware-setup.sh
+++ b/release/src/router/others/entware.mips/entware-setup.sh
@@ -14,13 +14,15 @@ echo -e $INFO This script will guide you through the Entware installation.
 echo -e $INFO Script modifies only \"entware\" folder on the chosen drive,
 echo -e $INFO no other data will be touched. Existing installation will be
 echo -e $INFO replaced with this one. Also some start scripts will be installed,
-echo -e $INFO the old ones will be saved to .\entware\jffs_scripts_backup.tgz
+echo -e $INFO the old ones will be saved on partition where Entware is installed
+echo -e $INFO like /tmp/mnt/sda1/jffs_scripts_backup.tgz
 echo 
 
 if [ ! -d /jffs/scripts ]
 then
-  echo -e "$ERROR Please enable JFFS partition from web UI, reboot router and"
-  echo -e "$ERROR try again.  Exiting..."
+  echo -e "$ERROR Please \"Enable JFFS partition\" & \"JFFS custom scripts and configs\""
+  echo -e "$ERROR from router web UI: www.asusrouter.com/Advanced_System_Content.asp"
+  echo -e "$ERROR then reboot router and try again. Exiting..."
   exit 1
 fi
 
@@ -47,10 +49,10 @@ then
   exit 0
 fi
 
-if [ "$partitionNumber" -gt `expr $i - 1` ]                                                           
-then                                                                                       
-  echo -e "$ERROR Invalid partition number!  Exiting..."                                                                 
-  exit 1                                                                                   
+if [ "$partitionNumber" -gt `expr $i - 1` ]
+then
+  echo -e "$ERROR Invalid partition number!  Exiting..."
+  exit 1
 fi
 
 eval entPartition=\$mounts$partitionNumber
@@ -59,8 +61,8 @@ entFolder=$entPartition/entware
 
 if [ -d $entFolder ]
 then
-  echo -e "$WARNING Found previous installation, deleting..."
-  rm -fr $entFolder
+  echo -e "$WARNING Found previous installation, saving..."
+  mv $entFolder $entFolder-old_`date +\%F_\%H-\%M`
 fi
 echo -e $INFO Creating $entFolder folder...
 mkdir $entFolder
@@ -74,7 +76,7 @@ echo -e $INFO Creating /tmp/opt symlink...
 ln -s $entFolder /tmp/opt
 
 echo -e $INFO Creating /jffs scripts backup...
-tar -czf $entPartition/jffs_scripts_backup.tgz /jffs/scripts/* >/dev/nul
+tar -czf $entPartition/jffs_scripts_backup_`date +\%F_\%H-\%M`.tgz /jffs/scripts/* >/dev/nul
 
 echo -e "$INFO Modifying start scripts..."
 cat > /jffs/scripts/services-start << EOF


### PR DESCRIPTION
When running the script, will delete existing entware installation if exists, we do not want this if there are a lot of packages installed or chrooted-debian is in that folder.
This patch will not delete but will save old installation as entware+date