### PR TITLE
adding the "brcmnand" device name to the mtd-erase2 for RT-AC68U

### DIFF
--- a/release/src/router/rc/rc.c
+++ b/release/src/router/rc/rc.c
@@ -777,7 +777,7 @@ int main(int argc, char **argv)
 				(!strcmp(argv[1], "linux")) ||
 				(!strcmp(argv[1], "linux2")) ||
 				(!strcmp(argv[1], "rootfs")) ||
-				(!strcmp(argv[1], "rootfs2")) ||
+				(!strcmp(argv[1], "brcmnand")) ||
 				(!strcmp(argv[1], "nvram")))) {
 			return mtd_erase(argv[1]);
 		} else {

--- a/release/src/router/rc/rc.c
+++ b/release/src/router/rc/rc.c
@@ -777,6 +777,7 @@ int main(int argc, char **argv)
 				(!strcmp(argv[1], "linux")) ||
 				(!strcmp(argv[1], "linux2")) ||
 				(!strcmp(argv[1], "rootfs")) ||
+				(!strcmp(argv[1], "rootfs2")) ||
 				(!strcmp(argv[1], "brcmnand")) ||
 				(!strcmp(argv[1], "nvram")))) {
 			return mtd_erase(argv[1]);


### PR DESCRIPTION
After I was unable to format my nand partition (broken after playing with different firmaware), I realized that the mtd-erase2 function could not work with RT-AC68U since the "brcmnand" is not listed in the device filter.