### PR TITLE
adding the "brcmnand" device name to the mtd-erase2 for RT-AC68U

### DIFF
--- a/release/src/router/rc/rc.c
+++ b/release/src/router/rc/rc.c
@@ -777,7 +777,7 @@ int main(int argc, char **argv)
 				(!strcmp(argv[1], "linux")) ||
 				(!strcmp(argv[1], "linux2")) ||
 				(!strcmp(argv[1], "rootfs")) ||
-				(!strcmp(argv[1], "rootfs2")) ||
+				(!strcmp(argv[1], "brcmnand")) ||
 				(!strcmp(argv[1], "nvram")))) {
 			return mtd_erase(argv[1]);
 		} else {

--- a/release/src/router/rc/rc.c
+++ b/release/src/router/rc/rc.c
@@ -777,6 +777,7 @@ int main(int argc, char **argv)
 				(!strcmp(argv[1], "linux")) ||
 				(!strcmp(argv[1], "linux2")) ||
 				(!strcmp(argv[1], "rootfs")) ||
+				(!strcmp(argv[1], "rootfs2")) ||
 				(!strcmp(argv[1], "brcmnand")) ||
 				(!strcmp(argv[1], "nvram")))) {
 			return mtd_erase(argv[1]);


### PR DESCRIPTION
Otherwise the missing device name make it impossible on rt-ac68u to format nand.