### PR TITLE
make entware initialization more robust

### DIFF
--- a/release/src/router/others/entware.arm/entware-setup.sh
+++ b/release/src/router/others/entware.arm/entware-setup.sh
@@ -81,9 +81,20 @@ tar -czf $entPartition/jffs_scripts_backup_`date +\%F_\%H-\%M`.tgz /jffs/scripts
 echo -e "$INFO Modifying start scripts..."
 cat > /jffs/scripts/services-start << EOF
 #!/bin/sh
+script="/opt/etc/init.d/rc.unslung"
 
-sleep 10
-/opt/etc/init.d/rc.unslung start
+i=60
+until [ -x "${script}" ]
+do
+        i=$(($i-1))
+        if [ "$i" -lt 1 ]
+        then
+                logger "Could not start Entware"
+                exit
+        fi
+        sleep 1
+done
+${script} start
 EOF
 chmod +x /jffs/scripts/services-start
 
@@ -99,7 +110,7 @@ cat > /jffs/scripts/post-mount << EOF
 
 if [ \$1 = "__Partition__" ]
 then
-  ln -sf \$1/entware.arm /tmp/opt
+  ln -nsf \$1/entware.arm /tmp/opt
 fi
 EOF
 eval sed -i 's,__Partition__,$entPartition,g' /jffs/scripts/post-mount

--- a/release/src/router/others/entware.mips/entware-setup.sh
+++ b/release/src/router/others/entware.mips/entware-setup.sh
@@ -81,9 +81,20 @@ tar -czf $entPartition/jffs_scripts_backup_`date +\%F_\%H-\%M`.tgz /jffs/scripts
 echo -e "$INFO Modifying start scripts..."
 cat > /jffs/scripts/services-start << EOF
 #!/bin/sh
+script="/opt/etc/init.d/rc.unslung"
 
-sleep 10
-/opt/etc/init.d/rc.unslung start
+i=60
+until [ -x "${script}" ]
+do
+        i=$(($i-1))
+        if [ "$i" -lt 1 ]
+        then
+                logger "Could not start Entware"
+                exit
+        fi
+        sleep 1
+done
+${script} start
 EOF
 chmod +x /jffs/scripts/services-start
 
@@ -99,7 +110,7 @@ cat > /jffs/scripts/post-mount << EOF
 
 if [ \$1 = "__Partition__" ]
 then
-  ln -sf \$1/entware /tmp/opt
+  ln -nsf \$1/entware /tmp/opt
 fi
 EOF
 eval sed -i 's,__Partition__,$entPartition,g' /jffs/scripts/post-mount


### PR DESCRIPTION
Two changes to make entware initialization more robust:
a) poll for the existence of rc.unslung, for a maximum of 60 seconds
b) make sure the symbolic link is always created by adding -n (--no-dereference option)
