### PR TITLE
Upnp changes

### DIFF
--- a/release/src/router/rc/firewall.c
+++ b/release/src/router/rc/firewall.c
@@ -2698,7 +2698,7 @@ TRACE_PT("writing Parental Control\n");
 
 		fprintf(fp_ipv6, "-A OUTPUT -m rt --rt-type 0 -j %s\n", logdrop);
 #ifdef RTCONFIG_IGD2
-		if (upnp_support_igd2() && nvram_match("upnp_enable", "1") && nvram_match("upnp_pinhole_enable", "1")) fprintf(fp_ipv6, "-A FORWARD -j UPNP\n");
+		if (nvram_match("upnp_enable", "1") && nvram_match("upnp_pinhole_enable", "1")) fprintf(fp_ipv6, "-A FORWARD -j UPNP\n");
 #endif
 
 		// IPv6 firewall - allowed traffic
@@ -3727,7 +3727,7 @@ TRACE_PT("writing Parental Control\n");
 		fprintf(fp_ipv6, "-A INPUT -j %s\n", logdrop);
 
 #ifdef RTCONFIG_IGD2
-		if (upnp_support_igd2() && nvram_match("upnp_enable", "1") && nvram_match("upnp_pinhole_enable", "1")) fprintf(fp_ipv6, "-A FORWARD -j UPNP\n");
+		if (nvram_match("upnp_enable", "1") && nvram_match("upnp_pinhole_enable", "1")) fprintf(fp_ipv6, "-A FORWARD -j UPNP\n");
 #endif
 
 		fprintf(fp_ipv6, "-A OUTPUT -m rt --rt-type 0 -j %s\n", logdrop);

--- a/release/src/router/rc/rc.h
+++ b/release/src/router/rc/rc.h
@@ -852,7 +852,6 @@ void start_cstats(int new);
 void restart_cstats(void);
 void stop_cstats(void);
 int ddns_custom_updated_main(int argc, char *argv[]);
-int upnp_support_igd2(void);
 
 // lan.c
 #ifdef RTCONFIG_TIMEMACHINE

--- a/release/src/router/rc/services.c
+++ b/release/src/router/rc/services.c
@@ -3124,15 +3124,6 @@ void stop_upnp(void)
 	killall_tk("miniupnpd");
 }
 
-int upnp_support_igd2(void)
-{
-#ifdef RTCONFIG_BCMARM
-	return 1;
-#else
-	return 0;
-#endif
-}
-
 int
 start_ntpc(void)
 {

--- a/release/src/router/rc/udhcpc.c
+++ b/release/src/router/rc/udhcpc.c
@@ -1085,7 +1085,9 @@ skip:
 			bound ? "bound" : "informed",
 			*address ? "address " : "", address, *address ? ", " : "",
 			*prefix ? "prefix " : "", prefix);
+#ifdef RTCONFIG_IGD2
 		notify_rc("restart_upnp");
+#endif
 	}
 
 	return 0;

--- a/release/src/router/www/Advanced_WAN_Content.asp
+++ b/release/src/router/www/Advanced_WAN_Content.asp
@@ -105,9 +105,8 @@ function initial(){
 function display_upnp_options(){
 	$("upnp_range_int").style.display = (document.form.wan_upnp_enable[0].checked) ? "" : "none";
 	$("upnp_range_ext").style.display = (document.form.wan_upnp_enable[0].checked) ? "" : "none";
-
-	if ((igd2_support) && ((based_modelid == "RT-N18U") || (based_modelid == "RT-AC56U") || (based_modelid == "RT-AC56S") || (based_modelid == "RT-AC68U") || (based_modelid == "RT-AC87U") || (based_modelid == "RT-AC68U") || (based_modelid == "RT-AC3200"))) {
-			$("upnp_pinhole").style.display = (document.form.wan_upnp_enable[0].checked) ? "" : "none";
+	if (igd2_support) {
+		$("upnp_pinhole").style.display = (document.form.wan_upnp_enable[0].checked) ? "" : "none";
 	} else {
 		$("upnp_pinhole").style.display = "none";
 	}

--- a/release/src/router/www/Main_IPV6Status_Content.asp
+++ b/release/src/router/www/Main_IPV6Status_Content.asp
@@ -32,7 +32,7 @@
 function initial() {
 	show_menu();
 
-	if ((igd2_support) && ((based_modelid == "RT-N18U") || (based_modelid == "RT-AC56U") || (based_modelid == "RT-AC56S") || (based_modelid == "RT-AC68U") || (based_modelid == "RT-AC87U") || (based_modelid == "RT-AC68U") || (based_modelid == "RT-AC3200")))
+	if (igd2_support)
 	{
 		$("pinholespan").style.display="";
 		show_pinholes();


### PR DESCRIPTION
restart_upnp when an IPv6 address is received via DHCP is only needed if miniupnpd was built with --ipv6, which is only the case when both RTCONFIG_IGD2 and RTCONFIG_IPV6 are defined.

The special casing for MIPS devices does not seem necessary anymore.