### PR TITLE
allow pasting in password input fields

### DIFF
--- a/release/src/router/www/Advanced_System_Content.asp
+++ b/release/src/router/www/Advanced_System_Content.asp
@@ -1012,7 +1012,7 @@ function toggle_jffs_visibility(state){
 				<tr>
 					<th width="40%"><a class="hintstyle" href="javascript:void(0);" onClick="openHint(11,4)"><#PASS_new#></a></th>
 					<td>
-						<input type="password" autocomplete="off" name="http_passwd2" tabindex="2" onKeyPress="return validator.isString(this, event);" onkeyup="chkPass(this.value, 'http_passwd');" onpaste="return false;" class="input_15_table" maxlength="16" onBlur="clean_scorebar(this);" autocorrect="off" autocapitalize="off"/>
+						<input type="password" autocomplete="off" name="http_passwd2" tabindex="2" onKeyPress="return validator.isString(this, event);" onkeyup="chkPass(this.value, 'http_passwd');" class="input_15_table" maxlength="16" onBlur="clean_scorebar(this);" autocorrect="off" autocapitalize="off"/>
 						&nbsp;&nbsp;
 						<div id="scorebarBorder" style="margin-left:140px; margin-top:-25px; display:none;" title="<#LANHostConfig_x_Password_itemSecur#>">
 							<div id="score"></div>
@@ -1024,7 +1024,7 @@ function toggle_jffs_visibility(state){
 				<tr>
 					<th><a class="hintstyle" href="javascript:void(0);" onClick="openHint(11,4)"><#PASS_retype#></a></th>
 					<td>
-						<input type="password" autocomplete="off" name="v_password2" tabindex="3" onKeyPress="return validator.isString(this, event);" onpaste="return false;" class="input_15_table" maxlength="16" autocorrect="off" autocapitalize="off"/>
+						<input type="password" autocomplete="off" name="v_password2" tabindex="3" onKeyPress="return validator.isString(this, event);" class="input_15_table" maxlength="16" autocorrect="off" autocapitalize="off"/>
 						<div style="margin:-25px 0px 5px 135px;"><input type="checkbox" name="show_pass_1" onclick="pass_checked(document.form.http_passwd2);pass_checked(document.form.v_password2);"><#QIS_show_pass#></div>
 						<span id="alert_msg2" style="color:#FC0;margin-left:8px;"></span>
 					

--- a/release/src/router/www/Main_Login.asp
+++ b/release/src/router/www/Main_Login.asp
@@ -215,7 +215,7 @@ function login(){
 					<tr style="height:42px;">
 						<td colspan="2">
 							<div style="margin:20px 0px 0px 78px;">
-								<input type="password" autocapitalization="off" autocomplete="off" value="" name="login_passwd" tabindex="2" class="form_input" maxlength="16" onkeyup="" onpaste="return false;"/ onBlur="" placeholder="Password">
+								<input type="password" autocapitalization="off" autocomplete="off" value="" name="login_passwd" tabindex="2" class="form_input" maxlength="16" onkeyup="" onBlur="" placeholder="Password">
 							</div>
 						</td>
 					</tr>

--- a/release/src/router/www/Main_Password.asp
+++ b/release/src/router/www/Main_Password.asp
@@ -319,14 +319,14 @@ function showError(str){
 					<tr style="height:72px;">
 						<td colspan="2">
 							<div style="margin:30px 0px 0px 78px;">
-								<input type="password" autocapitalization="off" autocomplete="off" value="" name="http_passwd" tabindex="2" class="form_input" maxlength="16" onkeyup="" onpaste="return false;"/ onBlur="" placeholder="<#PASS_new#>">
+								<input type="password" autocapitalization="off" autocomplete="off" value="" name="http_passwd" tabindex="2" class="form_input" maxlength="16" onkeyup="" onBlur="" placeholder="<#PASS_new#>">
 							</div>
 						</td>
 					</tr>
 					<tr style="height:72px;">
 						<td colspan="2">
 							<div style="margin:30px 0px 0px 78px;">
-								<input type="password" autocapitalization="off" autocomplete="off" value="" name="http_passwd_2" tabindex="3" class="form_input" maxlength="16" onkeyup="" onpaste="return false;"/ onBlur="" placeholder="<#Confirmpassword#>">
+								<input type="password" autocapitalization="off" autocomplete="off" value="" name="http_passwd_2" tabindex="3" class="form_input" maxlength="16" onkeyup="" onBlur="" placeholder="<#Confirmpassword#>">
 							</div>
 						</td>
 					</tr>

--- a/release/src/router/www/qis/QIS_admin_pass.htm
+++ b/release/src/router/www/qis/QIS_admin_pass.htm
@@ -346,7 +346,7 @@ function clean_scorebar(obj){
 		<tr>
 			<th width="240"><a class="hintstyle" href="javascript:void(0);" onClick="openHint(11,4)"><#PASS_new#></a></th>
 			<td class="QISformtd">
-				<input type="password" autocomplete="off" value="" name="http_passwd" tabindex="2" style="height:25px;" class="input_15_table" maxlength="16" onkeyup="chkPass(this.value, 'http_passwd');" onpaste="return false;"/ onBlur="clean_scorebar(this);" autocorrect="off" autocapitalize="off">
+				<input type="password" autocomplete="off" value="" name="http_passwd" tabindex="2" style="height:25px;" class="input_15_table" maxlength="16" onkeyup="chkPass(this.value, 'http_passwd');" onBlur="clean_scorebar(this);" autocorrect="off" autocapitalize="off">
 			&nbsp;&nbsp;
 			<div id="scorebarBorder" style="margin-left:140px; margin-top:-26px; display:none;" title="<#LANHostConfig_x_Password_itemSecur#>">
 				<div id="score" style="margin-top:3px;"></div>
@@ -357,7 +357,7 @@ function clean_scorebar(obj){
 		<tr>
 			<th width="240"><span class="hintstyle"><a class="hintstyle" href="javascript:void(0);" onClick="openHint(11,4)"><#PASS_retype#></a></span></th>
 			<td class="QISformtd">
-				<input type="password" autocomplete="off" value="" name="v_password2" tabindex="3" style="height:25px;" class="input_15_table" maxlength="16" onpaste="return false;" autocorrect="off" autocapitalize="off"/>
+				<input type="password" autocomplete="off" value="" name="v_password2" tabindex="3" style="height:25px;" class="input_15_table" maxlength="16" autocorrect="off" autocapitalize="off"/>
 				<div style="margin:-25px 0px 0px 135px;"><input type="checkbox" name="show_pass_1" tabindex="4" onclick="pass_checked(document.form.http_passwd);pass_checked(document.form.v_password2);"><#QIS_show_pass#></div>
 			</td>
 		</tr>


### PR DESCRIPTION
Disable pasting in input fields does not increase security.
It forces user to use weaker passwords because they are easier to type.
Password manager functionality is also broken with prevented pasting.

Good article about that topic:
http://www.wired.com/2015/07/websites-please-stop-blocking-password-managers-2015/