### PR TITLE
Fix bug with enware-setup.sh

### DIFF
--- a/release/src/router/others/entware.arm/entware-setup.sh
+++ b/release/src/router/others/entware.arm/entware-setup.sh
@@ -108,7 +108,7 @@ chmod +x /jffs/scripts/services-stop
 cat > /jffs/scripts/post-mount << EOF
 #!/bin/sh
 
-if [ \$1 = "__Partition__" ]
+if [ \$1 ="__Partition__"]
 then
   ln -nsf \$1/entware.arm /tmp/opt
 fi

--- a/release/src/router/others/entware.mips/entware-setup.sh
+++ b/release/src/router/others/entware.mips/entware-setup.sh
@@ -108,7 +108,7 @@ chmod +x /jffs/scripts/services-stop
 cat > /jffs/scripts/post-mount << EOF
 #!/bin/sh
 
-if [ \$1 = "__Partition__" ]
+if [ \$1 ="__Partition__"]
 then
   ln -nsf \$1/entware /tmp/opt
 fi


### PR DESCRIPTION
There is a bug with the post-mount script that is created by the entware-setup.sh script.

admin@RT-AC56U-A658:/tmp# /jffs/scripts/post-mount
[: /tmp/mnt/sda1: unknown operand

The issue is the whitespace around the = command.