### PR TITLE
Removing paste prevention for login password field

### DIFF
--- a/release/src/router/www/Main_Login.asp
+++ b/release/src/router/www/Main_Login.asp
@@ -307,7 +307,7 @@ function login(){
 				<input type="text" id="login_username" name="login_username" tabindex="1" class="form_input" maxlength="20" autocapitalization="off" autocomplete="off" placeholder="<#HSDPAConfig_Username_itemname#>">
 			</div>
 			<div class="password_gap">
-				<input type="password" name="login_passwd" tabindex="2" class="form_input" maxlength="16" onpaste="return false;" placeholder="<#HSDPAConfig_Password_itemname#>" autocapitalization="off" autocomplete="off">
+				<input type="password" name="login_passwd" tabindex="2" class="form_input" maxlength="16" placeholder="<#HSDPAConfig_Password_itemname#>" autocapitalization="off" autocomplete="off">
 			</div>
 			<div class="error_hint" style="display:none;" id="error_status_field"></div>
 				<div class="button" onclick="login();"><#CTL_signin#></div>
@@ -329,4 +329,3 @@ function login(){
 </form>
 </body>
 </html>
-


### PR DESCRIPTION
The current implementation does not improve security and punishes users using password database systems.