### PR TITLE
Fixing USB3 support for AC3200 and AC5300 (and possibly adding LVM support)

### DIFF
--- a/release/src/router/shared/defaults.c
+++ b/release/src/router/shared/defaults.c
@@ -1442,7 +1442,7 @@ struct nvram_tuple router_defaults[] = {
 	// NVRAM for start_usb
 	{ "usb_enable", "1"},
 #ifdef RTCONFIG_USB_XHCI
-#if defined(RTAC87U) || defined(DSL_AC68U)
+#if defined(RTAC87U) || defined(DSL_AC68U) || defined (RTAC3200) || defined(RTAC5300)
 	{ "usb_usb3", "1"},
 #else
 	{ "usb_usb3", "0"},


### PR DESCRIPTION
Over the past few days I've been trying to add LVM support to asuswrt. 

I got it to work and I can update the PR with all my changes if requested, however this change might be useful for anybody using the AC3200 and AC5300 (potentially). On my router, if I hook up a hard drive, asus_sd keeps resetting the USB subsystem if it can't mount a drive unless the nvram variable usb_usb3 is set to 1. I believe, since both of these routers have USB3, it should be set to 1. After I set it to 1 it does not keep resetting USB devices anymore.

Other changes I had to make for LVM to work:
- Compile Devicemapper modules (dm_*.ko)
- Add a custom hotplug2 script which scans added hard drives for LVM volumes and automounts them

Still working on correctly umounting them when they are unplugged. If you're interested in adding LVM support let me know and I'll make another PR once my code is mature enough.
