### PR TITLE
Enable creation of the mangle rules file for IPv6 Traditional QoS

### DIFF
--- a/release/src/router/rc/qos.c
+++ b/release/src/router/rc/qos.c
@@ -157,6 +157,9 @@ static int add_qos_rules(char *pcWANIF)
 	int v4v6_ok;
 
 	if((fn = fopen(mangle_fn, "w")) == NULL) return -2;
+#ifdef RTCONFIG_IPV6
+	if(ipv6_enabled() && (fn_ipv6 = fopen(mangle_fn_ipv6, "w")) == NULL) return -3;
+#endif
 
 	inuse = sticky_enable = 0;
 


### PR DESCRIPTION
This small patch which is actually a partial revert of 8e05587a1393ba93d93442d541ec05ccb20a7968 allows the /tmp/mangle_rules_ipv6 file to be created and filled with the appropriate rules when Traditional QoS is enabled on the router. I tested it on my RT-AC56U and it seems to be working as expected.