### PR TITLE
Configure OpenVPN to use iproute2 instead of net-tools

### DIFF
--- a/release/src/router/Makefile
+++ b/release/src/router/Makefile
@@ -3160,7 +3160,7 @@ openvpn-configure:
 		$(CONFIGURE) --prefix=/usr --bindir=/usr/sbin --libdir=/usr/lib \
 			--disable-debug --enable-management --disable-small \
 			--disable-selinux --disable-socks --enable-password-save \
-			--enable-plugin-auth-pam \
+			--enable-plugin-auth-pam --enable-iproute2 \
 			ac_cv_lib_resolv_gethostbyname=no \
 	)
 


### PR DESCRIPTION
On my system, the OpenVPN build fails at the configure step, claiming the `route` utility is missing. Looking at the Makefile, it's clear that it's not supposed to be using `route` but rather `ip` from iputils2, which needs to be explicitly enabled via `configure`.

It looks like this option was there before 9aa4283f31202657d3fa5fe088d34ba3638f2914 ("Merged with GPL 8596; Added SDK 7.14.114") but got deleted during the merge.