### PR TITLE
Remove passwd length limit

### DIFF
--- a/release/src/router/www/Main_Login.asp
+++ b/release/src/router/www/Main_Login.asp
@@ -410,7 +410,7 @@ function disable_button(val){
 				<input type="text" id="login_username" name="login_username" tabindex="1" class="form_input" maxlength="20" autocapitalize="off" autocomplete="off" placeholder="<#HSDPAConfig_Username_itemname#>">
 			</div>
 			<div class="password_gap">
-				<input type="password" name="login_passwd" tabindex="2" class="form_input" maxlength="16" placeholder="<#HSDPAConfig_Password_itemname#>" autocapitalize="off" autocomplete="off">
+				<input type="password" name="login_passwd" tabindex="2" class="form_input" placeholder="<#HSDPAConfig_Password_itemname#>" autocapitalize="off" autocomplete="off">
 			</div>
 			<div class="error_hint" style="display:none;" id="error_status_field"></div>
 				<div class="button" onclick="login();"><#CTL_signin#></div>


### PR DESCRIPTION
There is no limitation in password length when you're setting up the admin user, so, it shouldn't be checked on the login page. Actually, I'm using the 20 characters long password and need each time to use inspector to enter password with length more than 16 characters.