### PR TITLE
Let miniupnpd use the UUID API from libuuid

### DIFF
--- a/release/src/router/Makefile
+++ b/release/src/router/Makefile
@@ -1858,15 +1858,15 @@ else
 	cd miniupnpd && ./genconfig.sh --vendorcfg --leasefile
 endif
 
-miniupnpd: $(IPTABLES) miniupnpd/config.h
+miniupnpd: $(IPTABLES) e2fsprogs miniupnpd/config.h
 	@$(SEP)
 	cp -f ./shared/version.h miniupnpd$(MUVER)/.
 	PKG_CONFIG=false ARCH=$(PLATFORM) \
 	$(MAKE) -C $@ -f Makefile.merlin $(PARALLEL_BUILD) \
 	    IPTABLESPATH=$(TOP)/$(IPTABLES) \
-	    EXTRACFLAGS="-Os $(EXTRACFLAGS) -idirafter$(KERNEL_HEADER_DIR) -ffunction-sections -fdata-sections" \
-	    LDFLAGS="$(EXTRALDFLAGS) -ffunction-sections -fdata-sections -Wl,--gc-sections -L$(IPTC_LIBDIR)" \
-	    LDLIBS="-Wl,--as-needed $(IPTC_LIBS)"
+	    EXTRACFLAGS="-Os $(EXTRACFLAGS) -idirafter$(KERNEL_HEADER_DIR) -ffunction-sections -fdata-sections -I$(TOP)/e2fsprogs/lib" \
+	    LDFLAGS="$(EXTRALDFLAGS) -ffunction-sections -fdata-sections -Wl,--gc-sections -L$(IPTC_LIBDIR) -L$(TOP)/e2fsprogs/lib" \
+	    LDLIBS="-Wl,--as-needed $(IPTC_LIBS) -luuid"
 
 miniupnpd-clean:
 	-@$(MAKE) -C miniupnpd -f Makefile.merlin clean

--- a/release/src/router/miniupnpd/genconfig.sh
+++ b/release/src/router/miniupnpd/genconfig.sh
@@ -343,6 +343,7 @@ case $OS_NAME in
 #		echo "#ifdef RTCONFIG_IPV6" >> ${CONFIGFILE}
 #		echo "#define ENABLE_IPV6" >> ${CONFIGFILE}
 #		echo "#endif" >> ${CONFIGFILE}
+		echo "#define LIB_UUID" >> ${CONFIGFILE}
 		FW=netfilter
 		;;
 	Darwin)
@@ -385,12 +386,12 @@ case $FW in
 esac
 
 # UUID API
-if grep uuid_create /usr/include/uuid.h > /dev/null 2>&1 ; then
-	echo "#define BSD_UUID" >> ${CONFIGFILE}
-fi
-if grep uuid_generate /usr/include/uuid/uuid.h > /dev/null 2>&1 ; then
-	echo "#define LIB_UUID" >> ${CONFIGFILE}
-fi
+#if grep uuid_create /usr/include/uuid.h > /dev/null 2>&1 ; then
+#	echo "#define BSD_UUID" >> ${CONFIGFILE}
+#fi
+#if grep uuid_generate /usr/include/uuid/uuid.h > /dev/null 2>&1 ; then
+#	echo "#define LIB_UUID" >> ${CONFIGFILE}
+#fi
 
 # set V6SOCKETS_ARE_V6ONLY to 0 if it was not set above
 if [ -z "$V6SOCKETS_ARE_V6ONLY" ] ; then


### PR DESCRIPTION
Since miniupnp/miniupnp@6059f000f7e2d9c00c0abe1b3b6830a9d097bdad, miniupnpd can generate proper UUIDs for event subscribers using `uuid_*` library calls. The API is slightly different on Linux and BSD, so miniupnpd tries to detect which one is in use at compile time by grepping some system header files.

Since AsusWRT is cross-compiled, this doesn't work. In fact, if your build machine happens to have `/usr/include/uuid/uuid.h`, which is part of util-linux on most modern systems, miniupnp will conclude that libuuid is available on the *target* system and will \#ifdef in some function calls that aren't defined anywhere, breaking the build. If that header file isn't there, then it will fall back to using dummy UUIDs.

However, there actually is a real libuuid implementation in AsusWRT; it's part of e2fsprogs (there seem to be several implementations, but this is the only one that gets compiled and installed AFAICT). This patch tells miniupnpd to link to that library instead of guessing (and failing) based on what's installed on the host system.