### PR TITLE
Make "make clean" work again.

### DIFF
--- a/release/src/router/Makefile
+++ b/release/src/router/Makefile
@@ -47,7 +47,9 @@ else
 MODEL = $(subst -,,$(subst +,P,$(BUILD_NAME)))
 endif
 export CFLAGS += -D$(MODEL)
+ifneq ($(strip $(MODEL)),)
 export $(MODEL)=y
+endif
 
 export OLD_SRC=$(SRCBASE)/../src
 ifeq ($(RTCONFIG_BCMARM),y)


### PR DESCRIPTION
c19e98a added export $(MODEL)=y to line 50 in release/src/router/Makefile.
Variables BUILD_NAME and MODEL are empty during "make clean" so it stops
with this error:

Makefile:50: *** empty variable name.  Stop.
make[1]: Leaving directory '/tmp/merged/release/src/router'
Makefile:364: recipe for target 'clean' failed
make: *** [clean] Error 2