### PR TITLE
IPTraffic: get hostnames from static DHCP list

### DIFF
--- a/release/src/router/www/client_function.js
+++ b/release/src/router/www/client_function.js
@@ -3263,7 +3263,18 @@ function oui_query_web(mac){
 function clientFromIP(ip) {
 	for(var i=0; i<clientList.length;i++){
 		var clientObj = clientList[clientList[i]];
-		if(clientObj.ip == ip) return clientObj;
+		if(clientObj.ip == ip){
+			return clientObj;
+		}
+	}
+	staticList = originData.staticList;
+	for(var i=0; i<staticList.length; i++){
+		if(staticList[i] != ""){
+			data = staticList[i].split(">");
+			if(data[1] == ip){
+				return clientList[data[0]];
+			}
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
The function clientFromIP is only used in the files: 
- Main_TrafficMonitor_devdaily.asp 
- Main_TrafficMonitor_devrealtime.asp 
- Main_TrafficMonitor_devmonthly.asp

originData.staticList contains a list of the static DHCP ip adresses and mac adresses, i use this to make a lookup in the table.