### PR TITLE
rc: fix /etc/TZ in Japan

### DIFF
--- a/release/src/router/rc/common.c
+++ b/release/src/router/rc/common.c
@@ -1201,8 +1201,10 @@ void time_zone_x_mapping(void)
 	nvram_set("time_zone_x", tmpstr);
 
 	/* special mapping */
-	if (nvram_match("time_zone", "JST"))
+	if (nvram_match("time_zone", "JST")) {
 		nvram_set("time_zone_x", "UCT-9");
+		strncpy( tmpstr, "JST-9", sizeof( tmpstr )-1 );
+	}
 #if 0
 	else if (nvram_match("time_zone", "TST-10TDT"))
 		nvram_set("time_zone_x", "UCT-10");


### PR DESCRIPTION
little different "JST" at /etc/TZ in Japan

The "JST", select UTC in localtime();
Correctly, "JST-9" select JST in localtime();

$ echo "JST" > /etc/TZ; date
Sun Jan 29 10:00:49 UTC 2017
$ echo "JST-9" > /etc/TZ; date
Sun Jan 29 19:01:06 JST 2017