### PR TITLE
busybox: add clearhistory command to securely wipe the ash command history from memory

### DIFF
--- a/release/src/router/busybox/shell/ash.c
+++ b/release/src/router/busybox/shell/ash.c
@@ -9045,6 +9045,9 @@ returncmd(int argc UNUSED_PARAM, char **argv)
 
 /* Forward declarations for builtintab[] */
 static int breakcmd(int, char **) FAST_FUNC;
+#if ENABLE_FEATURE_EDITING
+static int clearhistorycmd(int, char **) FAST_FUNC;
+#endif
 static int dotcmd(int, char **) FAST_FUNC;
 static int evalcmd(int, char **) FAST_FUNC;
 static int exitcmd(int, char **) FAST_FUNC;
@@ -9109,6 +9112,9 @@ static const struct builtincmd builtintab[] = {
 	{ BUILTIN_SPEC_REG      "break"   , breakcmd   },
 	{ BUILTIN_REGULAR       "cd"      , cdcmd      },
 	{ BUILTIN_NOSPEC        "chdir"   , cdcmd      },
+#if ENABLE_FEATURE_EDITING
+	{ BUILTIN_NOSPEC        "clearhistory" , clearhistorycmd },
+#endif
 #if ENABLE_ASH_CMDCMD
 	{ BUILTIN_REGULAR       "command" , commandcmd },
 #endif
@@ -12612,6 +12618,17 @@ static int FAST_FUNC
 historycmd(int argc UNUSED_PARAM, char **argv UNUSED_PARAM)
 {
 	show_history(line_input_state);
+	return EXIT_SUCCESS;
+}
+#endif
+
+#if ENABLE_FEATURE_EDITING
+static int FAST_FUNC
+clearhistorycmd(int argc UNUSED_PARAM, char **argv UNUSED_PARAM)
+{
+	free_line_input_t(line_input_state);
+	line_input_state = new_line_input_t(FOR_SHELL | WITH_PATH_LOOKUP);
+
 	return EXIT_SUCCESS;
 }
 #endif

--- a/release/src/router/busybox/shell/ash.c
+++ b/release/src/router/busybox/shell/ash.c
@@ -12626,6 +12626,7 @@ historycmd(int argc UNUSED_PARAM, char **argv UNUSED_PARAM)
 static int FAST_FUNC
 clearhistorycmd(int argc UNUSED_PARAM, char **argv UNUSED_PARAM)
 {
+	remove(line_input_state->hist_file);
 	free_line_input_t(line_input_state);
 	line_input_state = new_line_input_t(FOR_SHELL | WITH_PATH_LOOKUP);
 


### PR DESCRIPTION
Your ash command history is held in memory until you close the login session.  The shell always holds the last 50 commands in memory, in addition to saving a history file `$HOME/.ash_history`.  When you type `history`, it's showing you the memory, not the file.  There is no way to clear it out.   _People are concerned because the password is there._

So, I've created a new command, named `clearhistory`, to securely wipe the entire ash command history from memory.  This is for people who need to immediately clear out their history after typing a password as a script parameter, during a SSH or telnet login session.  It's not for everyone; it's a very specific use-case.

Lastly, this new command does not attempt to clear out your history file, `$HOME/.ash_history`.  Theoretically, a history file could be written anywhere you've set your `$HOME` directory to.  Normally, this is `/root`, which is held in RAM, but it could be `/opt`, if that's where you set your `$HOME` directory to.
