### PR TITLE
Update Advanced_AiDisk_samba.asp, line 277: replace var j with var k and its references.

### DIFF
--- a/release/src/router/www/Advanced_AiDisk_samba.asp
+++ b/release/src/router/www/Advanced_AiDisk_samba.asp
@@ -274,12 +274,12 @@ function show_permissions_of_account(account_order, protocol){
 					continue;
 
 				permissions = get_account_permissions_in_pool(accountName, poolName);
-				for(var j = 1; j < permissions.length; ++j){
-					var folderBarCode = get_folderBarCode_in_pool(poolName, permissions[j][0]);
+				for(var k = 1; k < permissions.length; ++k){
+					var folderBarCode = get_folderBarCode_in_pool(poolName, permissions[k][0]);
 					if(protocol == "cifs")
-						showPermissionRadio(folderBarCode, permissions[j][1]);
+						showPermissionRadio(folderBarCode, permissions[k][1]);
 					else if(protocol == "ftp")
-						showPermissionRadio(folderBarCode, permissions[j][2]);
+						showPermissionRadio(folderBarCode, permissions[k][2]);
 					else{
 						alert("Wrong protocol when get permission!");	// system error msg. must not be translate
 						return;


### PR DESCRIPTION
Fix bug in UI where user permissions are not getting updated for multiple partitions of a samba shared USB disk. You'll see it's caused by a nested for (var j = ...)

To reproduce, attach USB disk with multiple partitions and multiple users. Try adjusting permissions for 2nd partition and switch between users.