### PR TITLE
fixed status bar layout in Chrome for large resolution screens

### DIFF
--- a/release/src/router/www/state.js
+++ b/release/src/router/www/state.js
@@ -666,7 +666,7 @@ function show_banner(L3){// L3 = The third Level of Menu
 	else {
 		banner_code +='<div id="banner1" class="banner1" align="center"><img src="images/New_ui/asustitle.png" width="218" height="54" align="left">\n';
 		banner_code +='<div style="margin-top:13px;margin-left:-90px;*margin-top:0px;*margin-left:0px;" align="center"><span id="modelName_top" onclick="this.focus();" class="modelName_top"><#Web_Title2#></span></div>';
-		banner_code +='<div style="margin-left:25px;width:160px;margin-top:0px;float:left;" align="left"><span><a href="https://asuswrt.lostrealm.ca/" target="_blank"><img src="images/merlin-logo.png" style="border: 0;"></span></div>';
+		banner_code +='<div style="margin-left:25px;width:160px;height:52px;;margin-top:0px;float:left;" align="left"><span><a href="https://asuswrt.lostrealm.ca/" target="_blank"><img src="images/merlin-logo.png" style="border: 0;"></span></div>';
 	}
 	// logout, reboot
 	banner_code +='<a href="javascript:logout();"><div style="margin-top:13px;margin-left:25px; *width:136px;" class="titlebtn" align="center"><span><#t1Logout#></span></div></a>\n';
@@ -678,7 +678,7 @@ function show_banner(L3){// L3 = The third Level of Menu
 	banner_code +='</ul>';
 
 	banner_code +='</div>\n';
-	banner_code +='<table width="998" border="0" align="center" cellpadding="0" cellspacing="0" class="statusBar">\n';
+	banner_code +='<table width="998" border="0" align="center" cellpadding="0" cellspacing="0" class="statusBar" style="margin:auto;">\n';
 	banner_code +='<tr>\n';
 	banner_code +='<td background="images/New_ui/midup_bg.png" height="179" valign="top"><table width="764" border="0" cellpadding="0" cellspacing="0" height="35px" style="margin-left:230px;">\n';
 	banner_code +='<tbody><tr>\n';


### PR DESCRIPTION
In Chrome, when the window is larger than 1803 px the status bar is pushed to the right of the screen, breaking the layout.

I don't quite know why the limit is at 1803 px but that's the result of my finding.
_The error seem to have something to do with overflow of the div with style class "banner1"._

I have not found the same issue in Edge (the only other browser I've tested this with), but the changes does not break the correct layout in Edge.

Including screenshot of the before picture:

![asus large](https://user-images.githubusercontent.com/20536256/26985001-e287b5b8-4d41-11e7-88b2-6fea1b799b9a.PNG)
