### PR TITLE
Add space before WAN IP

### DIFF
--- a/release/src/router/www/Advanced_VPN_PPTP.asp
+++ b/release/src/router/www/Advanced_VPN_PPTP.asp
@@ -92,7 +92,7 @@ function initial(){
 		
 		var wan_ipaddr = wanlink_ipaddr();
 
-		document.getElementById("wan_ctrl").innerHTML = "<#PPTP_desc2#>" +  wan_ipaddr;
+		document.getElementById("wan_ctrl").innerHTML = "<#PPTP_desc2#> " +  wan_ipaddr;
 
 		//check DUT is belong to private IP.
 		setTimeout("show_warning_message();", 100);


### PR DESCRIPTION
Frm the web interface we are missing an empty space between PPTP_desc2 and wan_ipaddr