### PR TITLE
Output hostname for packages requests

### DIFF
--- a/release/src/router/others/hostname
+++ b/release/src/router/others/hostname
@@ -1,0 +1,2 @@
+#!/bin/sh
+cat /proc/sys/kernel/hostname


### PR DESCRIPTION
Some optware/entware packages require hostname on installation but get no output, this file will solve this.
````-sh: hostname: not found````
After
RT-AC68U