### PR TITLE
380.69_x

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -7,6 +7,7 @@ Asuswrt-Merlin Changelog
            the Sysinfo page.
   - FIXED: Port forward/UPNP issues with CTF enabled depending on
            selected NAT loopback mode.
+  - FIXED: URL filtering wasn't working over IPv4.
 
 
 380.67 (16-July-2017)

--- a/release/src/router/rc/firewall.c
+++ b/release/src/router/rc/firewall.c
@@ -3075,7 +3075,7 @@ TRACE_PT("write url filter\n");
 			if (vstrsep(b, ">", &filterstr) != 1)
 				continue;
 			if (*filterstr) {
-
+				fprintf(fp, "-I FORWARD -p tcp %s -m webstr --url \"%s\" -j REJECT --reject-with tcp-reset\n", timef, filterstr);
 #ifdef RTCONFIG_IPV6
 				if (ipv6_enabled())
 					fprintf(fp_ipv6, "-I FORWARD -p tcp %s -m webstr --url \"%s\" -j REJECT --reject-with tcp-reset\n", timef, filterstr);


### PR DESCRIPTION
I apologize for my English, translated by Google

in 380.69 firmware encountered such a problem
in the settings of port forwarding is configured for deployment at the ports for WoL and RDP to local computers

before everything worked fine, now I have the feeling that everything is tightly closed and not a single port to the outside is not visible

I try to Wake up on a local network the computer-everything works, through "Network Tools - Wake on LAN" everything works, but from the Internet in General any reaction

same thing with RDP on a local network all connected, but from the outside does not work anything
iptables has not been touched, in the firewall too, no settings changed, tried it completely disabled, still not working

what happened to port forwarding, why did it stop working?
somehow it is possible to restore correct work?